### PR TITLE
feat: add desktop adb preflight via system CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,13 @@ npm test
 npm run lint
 npm start
 ```
+
+## Current Desktop Slice
+
+The desktop app now includes a minimal ADB preflight path:
+
+- checks that the system `adb` CLI is available
+- starts the adb server if needed
+- lists connected Android devices and their authorization state
+
+This uses the host `adb` binary through Electron main-process `spawn()` and does not add any npm ADB library yet.

--- a/docs/SESSION_STATE.md
+++ b/docs/SESSION_STATE.md
@@ -32,6 +32,7 @@ Audience: operator desktop companion for the Android scanner app
   - initial Electron scaffold
   - repo guardrails in `CLAUDE.md`
   - dependency/CI hardening from PR `#4`
+  - system-`adb` preflight UI for device detection / authorization checks
 - CI now runs:
   - `npm ci`
   - `npm test`
@@ -49,9 +50,11 @@ Audience: operator desktop companion for the Android scanner app
 ## Current file roles
 
 - `src/main.mjs` — Electron main process with hardened `BrowserWindow` defaults
-- `src/preload.mjs` — minimal preload bridge
-- `src/index.html` — static shell only
-- `test/scaffold.test.mjs` — baseline regression tests for ESM-only package shape and secure window defaults
+- `src/preload.mjs` — minimal preload bridge plus ADB preflight IPC surface
+- `src/index.html` — static shell with ADB preflight entry point
+- `src/adb-preflight.mjs` — pure parser/summarizer for `adb devices -l` output
+- `src/renderer.mjs` — minimal renderer for local ADB preflight feedback
+- `test/scaffold.test.mjs` — baseline regression tests for ESM-only package shape, secure window defaults, and ADB preflight parsing
 - `.github/workflows/ci.yml` — minimal CI gate for install, test, and lint
 - `CLAUDE.md` — repo-local agent rules and workflow constraints
 
@@ -65,6 +68,7 @@ Audience: operator desktop companion for the Android scanner app
 - `@u4/adbkit` remains deferred because it is CJS-only
 - Tango ADB is the preferred future evaluation candidate
 - No scan orchestration UI, no live Android bridge, and no local web dashboard yet
+- Current desktop ADB scope is limited to preflight only: no device selection, no install flow, no port forwarding, and no shell orchestration yet
 - Future desktop ADB implementation should start from the validated host-side command set in `docs/ADB_WORKFLOW.md`
 - Newer Pixel devices may run with Advanced Protection enabled and a built-in Linux terminal VM present; neither should be treated as edge-case-only
 

--- a/src/adb-preflight.mjs
+++ b/src/adb-preflight.mjs
@@ -1,0 +1,40 @@
+export function parseAdbDevices(output) {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("List of devices attached"))
+    .map((line) => {
+      const segments = line.split(/\s+/);
+      const [serial = "", state = "unknown", ...details] = segments;
+      const metadata = Object.fromEntries(
+        details
+          .filter((segment) => segment.includes(":"))
+          .map((segment) => {
+            const separatorIndex = segment.indexOf(":");
+            return [
+              segment.slice(0, separatorIndex),
+              segment.slice(separatorIndex + 1),
+            ];
+          }),
+      );
+
+      return {
+        serial,
+        state,
+        model: metadata.model ?? "",
+        product: metadata.product ?? "",
+        device: metadata.device ?? "",
+      };
+    });
+}
+
+export function summarizePreflight(versionOutput, devicesOutput) {
+  const adbVersion = versionOutput.split(/\r?\n/)[0]?.trim() ?? "";
+  const devices = parseAdbDevices(devicesOutput);
+
+  return {
+    ok: true,
+    adbVersion,
+    devices,
+  };
+}

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,10 @@
 </head>
 <body>
   <h1>wscan+ Desktop Hub</h1>
-  <p>Phase 3</p>
+  <p>ADB onboarding preflight for the Android companion.</p>
+  <button id="run-preflight" type="button">Run ADB Preflight</button>
+  <p id="status">Ready.</p>
+  <ul id="device-list"></ul>
+  <script type="module" src="./renderer.mjs"></script>
 </body>
 </html>

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -1,8 +1,55 @@
-import { app, BrowserWindow } from "electron";
+import { app, BrowserWindow, ipcMain } from "electron";
+import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { summarizePreflight } from "./adb-preflight.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function runAdb(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("adb", args, {
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", (error) => {
+      reject(error);
+    });
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve(stdout);
+        return;
+      }
+
+      reject(new Error(stderr.trim() || `adb exited with code ${code}`));
+    });
+  });
+}
+
+ipcMain.handle("adb:preflight", async () => {
+  try {
+    await runAdb(["start-server"]);
+    const versionOutput = await runAdb(["version"]);
+    const devicesOutput = await runAdb(["devices", "-l"]);
+    return summarizePreflight(versionOutput, devicesOutput);
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "ADB preflight failed.",
+    };
+  }
+});
 
 function createWindow() {
   const win = new BrowserWindow({

--- a/src/preload.mjs
+++ b/src/preload.mjs
@@ -1,3 +1,7 @@
 import { contextBridge } from "electron";
+import { ipcRenderer } from "electron";
 
-contextBridge.exposeInMainWorld("wscan", { version: "0.1.0" });
+contextBridge.exposeInMainWorld("wscan", {
+  version: "0.1.0",
+  runAdbPreflight: () => ipcRenderer.invoke("adb:preflight"),
+});

--- a/src/renderer.mjs
+++ b/src/renderer.mjs
@@ -1,0 +1,61 @@
+const statusElement = document.getElementById("status");
+const runButton = document.getElementById("run-preflight");
+const deviceList = document.getElementById("device-list");
+
+function clearDeviceList() {
+  while (deviceList.firstChild) {
+    deviceList.removeChild(deviceList.firstChild);
+  }
+}
+
+function renderDevices(devices) {
+  clearDeviceList();
+
+  for (const device of devices) {
+    const item = document.createElement("li");
+    const parts = [
+      device.model || "Unknown model",
+      `state=${device.state}`,
+    ];
+
+    if (device.product) {
+      parts.push(`product=${device.product}`);
+    }
+
+    if (device.device) {
+      parts.push(`device=${device.device}`);
+    }
+
+    item.textContent = parts.join(" | ");
+    deviceList.appendChild(item);
+  }
+}
+
+async function runPreflight() {
+  statusElement.textContent = "Running ADB preflight...";
+  runButton.disabled = true;
+  clearDeviceList();
+
+  try {
+    const result = await window.wscan.runAdbPreflight();
+
+    if (!result.ok) {
+      statusElement.textContent = result.error;
+      return;
+    }
+
+    if (result.devices.length === 0) {
+      statusElement.textContent = `${result.adbVersion} | No Android devices detected.`;
+      return;
+    }
+
+    statusElement.textContent = `${result.adbVersion} | ${result.devices.length} device(s) detected.`;
+    renderDevices(result.devices);
+  } finally {
+    runButton.disabled = false;
+  }
+}
+
+runButton.addEventListener("click", () => {
+  void runPreflight();
+});

--- a/test/scaffold.test.mjs
+++ b/test/scaffold.test.mjs
@@ -28,4 +28,40 @@ test("main process keeps hardened BrowserWindow defaults", () => {
   assert.match(mainSource, /contextIsolation:\s*true/);
   assert.match(mainSource, /nodeIntegration:\s*false/);
   assert.match(mainSource, /loadFile\(path\.join\(__dirname,\s*"index\.html"\)\)/);
+  assert.match(mainSource, /spawn\("adb",\s*args/);
+  assert.doesNotMatch(mainSource, /\bexec\(/);
+});
+
+test("adb preflight parser extracts state and metadata from adb devices output", async () => {
+  const { parseAdbDevices, summarizePreflight } = await import("../src/adb-preflight.mjs");
+  const devices = parseAdbDevices(`List of devices attached
+DEVICE123456\tdevice product:grail model:Pixel_10_Pro_XL device:grail
+UNAUTHORIZED1\tunauthorized usb:1-1 transport_id:3
+`);
+
+  assert.deepEqual(devices, [
+    {
+      serial: "DEVICE123456",
+      state: "device",
+      model: "Pixel_10_Pro_XL",
+      product: "grail",
+      device: "grail",
+    },
+    {
+      serial: "UNAUTHORIZED1",
+      state: "unauthorized",
+      model: "",
+      product: "",
+      device: "",
+    },
+  ]);
+
+  const summary = summarizePreflight(
+    "Android Debug Bridge version 1.0.41\nVersion 36.0.0-13206524",
+    "List of devices attached\n\n",
+  );
+
+  assert.equal(summary.ok, true);
+  assert.equal(summary.adbVersion, "Android Debug Bridge version 1.0.41");
+  assert.deepEqual(summary.devices, []);
 });


### PR DESCRIPTION
## Summary
- agent: Copilot / Codex
- closes #9
- add the first desktop implementation slice using the system `adb` CLI instead of an npm ADB library
- expose a minimal preflight UI that checks whether `adb` is available and whether connected devices are detected / authorized

## Why
- the desktop repo intentionally deferred library-based ADB work because `@u4/adbkit` is CJS-only and conflicts with the ESM-only rule
- a host-side preflight path is the smallest useful implementation slice for later Android companion onboarding
- this keeps the scope tight: no install flow, no device selection, no port forwarding, and no shell orchestration yet

## Verification
- `npm test`
- `npm run lint`
