### PR TITLE
feat: engine hardening, preload bridge, and MVP UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "wscanplus-desktop",
       "version": "0.1.0",
+      "dependencies": {
+        "ws": "8.20.0"
+      },
       "devDependencies": {
         "electron": "41.0.3",
         "electron-builder": "26.8.1",
@@ -5631,6 +5634,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "lint": "eslint src/",
     "build": "electron-builder"
   },
+  "dependencies": {
+    "ws": "8.20.0"
+  },
   "devDependencies": {
     "electron": "41.0.3",
     "electron-builder": "26.8.1",

--- a/src/companion-server.mjs
+++ b/src/companion-server.mjs
@@ -117,6 +117,7 @@ export class CompanionServer {
         if (
           msg.type !== "auth" ||
           !this.#token ||
+          typeof msg.token !== "string" ||
           msg.token !== this.#token
         ) {
           ws.close(1008, "Authentication failed");
@@ -150,7 +151,7 @@ export class CompanionServer {
     const { deviceId, sequence, timestamp, networks } = payload;
 
     if (typeof deviceId !== "string" || !deviceId) return false;
-    if (typeof sequence !== "number") return false;
+    if (!Number.isInteger(sequence)) return false;
     if (!Array.isArray(networks)) return false;
 
     // Reject stale timestamps

--- a/src/companion-server.mjs
+++ b/src/companion-server.mjs
@@ -1,0 +1,185 @@
+import { createServer } from "node:http";
+import { randomBytes } from "node:crypto";
+import { WebSocketServer } from "ws";
+
+const MAX_STALE_MS = 2 * 60 * 1000;   // 2 minutes
+const RATE_LIMIT_PER_WINDOW = 10;
+const RATE_LIMIT_WINDOW_MS = 1_000;
+
+/**
+ * Validate that a payload timestamp is within the acceptable staleness window.
+ */
+export function isTimestampFresh(
+  timestamp,
+  nowMs = Date.now(),
+  maxStalenessMs = MAX_STALE_MS,
+) {
+  return typeof timestamp === "number" &&
+    Math.abs(nowMs - timestamp) <= maxStalenessMs;
+}
+
+/**
+ * Validate that a sequence number is strictly greater than the last seen
+ * sequence for this device (monotonic enforcement).
+ */
+export function isSequenceMonotonic(deviceId, sequence, sessions) {
+  const session = sessions.get(deviceId);
+  return !session || sequence > session.sequence;
+}
+
+function newSession() {
+  return { sequence: -1, rateCount: 0, rateWindowStart: Date.now() };
+}
+
+/**
+ * WebSocket server for the Android companion sensor.
+ *
+ * Security model:
+ * - Binds to 127.0.0.1 by default (LAN exposure is explicit opt-in)
+ * - Requires token-based pairing before any scan data is accepted
+ * - Rejects payloads with stale timestamps (>2 min)
+ * - Enforces strictly monotonic sequence numbers per device
+ * - Rate-limits messages per device per second
+ */
+export class CompanionServer {
+  #token = null;
+  #sessions = new Map();
+  #httpServer = null;
+  #wss = null;
+  #onData = null;
+
+  constructor({ onData } = {}) {
+    this.#onData = onData ?? null;
+  }
+
+  /**
+   * Generate (or regenerate) the pairing token.
+   * Returns the token string. Share this out-of-band with the Android app.
+   */
+  generateToken() {
+    this.#token = randomBytes(16).toString("hex");
+    return this.#token;
+  }
+
+  get token() {
+    return this.#token;
+  }
+
+  get address() {
+    return this.#httpServer?.address() ?? null;
+  }
+
+  /**
+   * Start the WebSocket server.
+   * @param {number} port - 0 = OS-assigned. Use process.env.COMPANION_PORT for override.
+   * @param {string} host - defaults to 127.0.0.1 (localhost-only)
+   */
+  start(port = 0, host = "127.0.0.1") {
+    if (this.#httpServer) return Promise.resolve(this.address);
+    return new Promise((resolve, reject) => {
+      this.#httpServer = createServer();
+      this.#wss = new WebSocketServer({ server: this.#httpServer });
+      this.#wss.on("connection", (ws) => this.#handleConnection(ws));
+      this.#httpServer.on("error", reject);
+      this.#httpServer.listen(port, host, () => resolve(this.address));
+    });
+  }
+
+  stop() {
+    return new Promise((resolve) => {
+      if (!this.#httpServer) {
+        resolve();
+        return;
+      }
+      this.#wss?.close();
+      this.#httpServer.close(() => {
+        this.#httpServer = null;
+        this.#wss = null;
+        resolve();
+      });
+    });
+  }
+
+  #handleConnection(ws) {
+    let authenticated = false;
+
+    ws.on("message", (raw) => {
+      let msg;
+      try {
+        msg = JSON.parse(raw.toString());
+      } catch {
+        ws.close(1008, "Invalid JSON");
+        return;
+      }
+
+      // First message must be auth
+      if (!authenticated) {
+        if (
+          msg.type !== "auth" ||
+          !this.#token ||
+          msg.token !== this.#token
+        ) {
+          ws.close(1008, "Authentication failed");
+          return;
+        }
+        authenticated = true;
+        ws.send(JSON.stringify({ type: "auth_ok" }));
+        return;
+      }
+
+      if (msg.type !== "scan") return;
+
+      if (!this.#validatePayload(ws, msg.payload)) return;
+
+      const { deviceId, sequence } = msg.payload;
+      const session = this.#sessions.get(deviceId) ?? newSession();
+      session.sequence = sequence;
+      this.#sessions.set(deviceId, session);
+
+      this.#onData?.(msg.payload);
+    });
+
+    ws.on("error", () => {
+      /* connection close is handled by the 'close' event */
+    });
+  }
+
+  #validatePayload(ws, payload) {
+    if (!payload || typeof payload !== "object") return false;
+
+    const { deviceId, sequence, timestamp, networks } = payload;
+
+    if (typeof deviceId !== "string" || !deviceId) return false;
+    if (typeof sequence !== "number") return false;
+    if (!Array.isArray(networks)) return false;
+
+    // Reject stale timestamps
+    if (!isTimestampFresh(timestamp)) return false;
+
+    // Enforce monotonic sequence
+    if (!isSequenceMonotonic(deviceId, sequence, this.#sessions)) return false;
+
+    // Rate limit
+    if (!this.#checkRateLimit(deviceId)) {
+      ws.close(1008, "Rate limit exceeded");
+      return false;
+    }
+
+    return true;
+  }
+
+  #checkRateLimit(deviceId) {
+    const session = this.#sessions.get(deviceId) ?? newSession();
+    const now = Date.now();
+
+    if (now - session.rateWindowStart > RATE_LIMIT_WINDOW_MS) {
+      session.rateCount = 0;
+      session.rateWindowStart = now;
+    }
+
+    session.rateCount += 1;
+    this.#sessions.set(deviceId, session);
+
+    return session.rateCount <= RATE_LIMIT_PER_WINDOW;
+  }
+}

--- a/src/detector.mjs
+++ b/src/detector.mjs
@@ -1,0 +1,81 @@
+export const SEVERITY = Object.freeze({
+  HIGH: "high",
+  MEDIUM: "medium",
+  LOW: "low",
+  INFO: "info",
+});
+
+const SEVERITY_ORDER = [SEVERITY.INFO, SEVERITY.LOW, SEVERITY.MEDIUM, SEVERITY.HIGH];
+
+function bumpSeverity(current, next) {
+  const a = SEVERITY_ORDER.indexOf(current);
+  const b = SEVERITY_ORDER.indexOf(next);
+  return SEVERITY_ORDER[Math.max(a, b)];
+}
+
+/**
+ * Score a single AP against the known AP baseline.
+ * Returns a deterministic score object with explicit reasons.
+ * No ML, no inference beyond the observed signals.
+ */
+export function scoreAP(ap, baselineAps = new Map()) {
+  const reasons = [];
+  let severity = SEVERITY.INFO;
+
+  // Hidden SSID
+  if (!ap.ssid || ap.ssid.length === 0) {
+    reasons.push("Hidden SSID");
+    severity = bumpSeverity(severity, SEVERITY.LOW);
+  }
+
+  // Open network (no encryption)
+  if (ap.security === "open") {
+    reasons.push("No encryption (open network)");
+    severity = bumpSeverity(severity, SEVERITY.LOW);
+  }
+
+  // WEP — deprecated and trivially broken
+  if (ap.security === "wep") {
+    reasons.push("WEP encryption (deprecated, trivially broken)");
+    severity = bumpSeverity(severity, SEVERITY.MEDIUM);
+  }
+
+  // Exceptionally strong signal — may indicate co-located rogue AP
+  if (ap.signal > -30) {
+    reasons.push(
+      `Exceptionally strong signal (${ap.signal} dBm) — possible co-located rogue`,
+    );
+    severity = bumpSeverity(severity, SEVERITY.MEDIUM);
+  }
+
+  // SSID collision — same name as a known AP but different BSSID
+  if (ap.ssid && ap.ssid.length > 0) {
+    for (const [knownBssid, knownAp] of baselineAps) {
+      if (knownBssid !== ap.bssid && knownAp.ssid === ap.ssid) {
+        reasons.push(`SSID collision: same name as known AP ${knownBssid}`);
+        severity = bumpSeverity(severity, SEVERITY.HIGH);
+        break;
+      }
+    }
+  }
+
+  const confidence =
+    reasons.length === 0 ? 0 : Math.min(0.9, 0.3 + reasons.length * 0.2);
+
+  return {
+    bssid: ap.bssid,
+    ssid: ap.ssid,
+    severity,
+    reasons,
+    confidence,
+  };
+}
+
+/**
+ * Score all APs. Returns only entries that have at least one reason.
+ */
+export function scoreAPs(aps, baselineAps = new Map()) {
+  return aps
+    .map((ap) => scoreAP(ap, baselineAps))
+    .filter((s) => s.reasons.length > 0);
+}

--- a/src/index.html
+++ b/src/index.html
@@ -7,15 +7,135 @@
     content="default-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'; base-uri 'none'"
   >
   <title>wscan+</title>
+  <link rel="stylesheet" href="./styles.css">
 </head>
 <body>
-  <h1>wscan+ Desktop Hub</h1>
-  <p>ADB onboarding preflight for the Android companion.</p>
-  <p id="trusted-host">Only trust this desktop if it is private and under your control.</p>
-  <button id="run-preflight" type="button">Run ADB Preflight</button>
-  <p id="status">Ready.</p>
-  <p id="guidance">Run the preflight to see the next operator step.</p>
-  <ul id="device-list"></ul>
+  <div class="shell">
+
+    <!-- ── Left nav ─────────────────────────────────────────────────── -->
+    <nav class="nav-rail">
+      <div class="nav-brand">wscan+</div>
+      <button class="nav-btn active" type="button" data-view="scan">Scan</button>
+      <button class="nav-btn" type="button" data-view="devices">Devices</button>
+      <button class="nav-btn" type="button" data-view="companion">Companion</button>
+    </nav>
+
+    <!-- ── Center workspace ─────────────────────────────────────────── -->
+    <main class="workspace">
+
+      <!-- Scan view: AP table + threat queue -->
+      <section class="view active" id="view-scan">
+        <div class="view-header">
+          <span class="view-title">Scan</span>
+          <div class="tab-bar">
+            <button class="tab active" type="button" data-tab="aps">
+              Access Points <span class="badge" id="ap-count">0</span>
+            </button>
+            <button class="tab" type="button" data-tab="threats">
+              Threats <span class="badge" id="threat-count">0</span>
+            </button>
+          </div>
+          <div class="scan-controls">
+            <select class="iface-select" id="iface-select">
+              <option value="">Auto-detect</option>
+            </select>
+            <button class="btn btn-primary" id="btn-start" type="button">Start</button>
+            <button class="btn" id="btn-stop" type="button" disabled>Stop</button>
+            <button class="btn" id="btn-manual" type="button">Scan Now</button>
+            <span class="scan-badge" id="scan-badge">Idle</span>
+          </div>
+        </div>
+
+        <div class="tab-panel active" id="panel-aps">
+          <div class="table-wrap">
+            <table class="ap-table">
+              <thead>
+                <tr>
+                  <th>SSID</th>
+                  <th>BSSID</th>
+                  <th>Signal</th>
+                  <th>Ch</th>
+                  <th>Security</th>
+                  <th>Risk</th>
+                  <th>Last seen</th>
+                </tr>
+              </thead>
+              <tbody id="ap-tbody"></tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="tab-panel" id="panel-threats">
+          <ul class="threat-list" id="threat-list"></ul>
+        </div>
+      </section>
+
+      <!-- Devices view: ADB preflight -->
+      <section class="view" id="view-devices">
+        <div class="view-header">
+          <span class="view-title">Devices</span>
+          <button class="btn btn-primary" id="run-preflight" type="button">
+            Run ADB Preflight
+          </button>
+        </div>
+        <div class="devices-content">
+          <p class="trusted-host-notice" id="trusted-host">
+            Only trust this desktop if it is private and under your control.
+          </p>
+          <p id="status">Ready.</p>
+          <p id="guidance">Run the preflight to see the next operator step.</p>
+          <ul id="device-list"></ul>
+        </div>
+      </section>
+
+      <!-- Companion view: pairing + connected devices -->
+      <section class="view" id="view-companion">
+        <div class="view-header">
+          <span class="view-title">Companion</span>
+        </div>
+        <div class="companion-content">
+          <div class="companion-section">
+            <div class="section-label">Pairing</div>
+            <p class="section-note">
+              Generate a token and enter it in the companion app to authorise
+              the connection. The server binds to localhost only unless
+              <code>COMPANION_HOST</code> is set.
+            </p>
+            <button class="btn btn-primary" id="btn-pair" type="button">
+              Generate Pairing Token
+            </button>
+            <div class="token-block" id="token-block" hidden>
+              <div class="token-label">Token</div>
+              <div class="token-value mono" id="token-value"></div>
+              <div class="token-addr" id="token-addr"></div>
+            </div>
+          </div>
+          <div class="companion-section">
+            <div class="section-label">Connected devices</div>
+            <ul class="companion-device-list" id="companion-device-list">
+              <li class="companion-empty">No devices connected</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+    </main>
+
+    <!-- ── Right inspector ──────────────────────────────────────────── -->
+    <aside class="inspector">
+      <div class="inspector-header">Inspector</div>
+      <div id="inspector-content">
+        <p class="inspector-empty">Select an AP to inspect</p>
+      </div>
+    </aside>
+
+    <!-- ── Bottom log drawer ────────────────────────────────────────── -->
+    <footer class="log-drawer">
+      <div class="log-header">Event Log</div>
+      <div class="log-entries" id="log-entries"></div>
+    </footer>
+
+  </div>
   <script type="module" src="./renderer.mjs"></script>
 </body>
 </html>

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -10,9 +10,20 @@ import {
   summarizePreflight,
   validateDeviceSelector,
 } from "./adb-preflight.mjs";
+import { store } from "./store.mjs";
+import {
+  startScanning,
+  stopScanning,
+  executeScanCycle,
+  detectInterfaces,
+} from "./scanner.mjs";
+import { CompanionServer } from "./companion-server.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const COMPANION_PACKAGE = "com.wscanplus.app";
+const COMPANION_PORT = parseInt(process.env.COMPANION_PORT ?? "47392", 10);
+
+// --- ADB helpers (unchanged) ---
 
 function unknownCompanion() {
   return {
@@ -146,6 +157,8 @@ async function attachCompanionStatus(devices) {
   return results;
 }
 
+// --- IPC: ADB preflight (unchanged) ---
+
 ipcMain.handle("adb:preflight", async () => {
   try {
     await runAdb(["start-server"]);
@@ -187,8 +200,130 @@ ipcMain.handle("adb:preflight", async () => {
   }
 });
 
+// --- IPC: Scanner ---
+
+ipcMain.handle("scan:start", async (_, iface) => {
+  try {
+    await startScanning(iface || undefined);
+    return { ok: true, interface: store.state.interface };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+});
+
+ipcMain.handle("scan:stop", () => {
+  stopScanning();
+  return { ok: true };
+});
+
+ipcMain.handle("scan:manual", async () => {
+  try {
+    const aps = await executeScanCycle();
+    return { ok: true, count: aps.length };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+});
+
+ipcMain.handle("scan:state", () => ({
+  scanning: store.state.scanning,
+  interface: store.state.interface,
+  scanIntervalMs: store.state.scanIntervalMs,
+  apCount: store.state.aps.size,
+  riskCount: store.state.riskLog.length,
+}));
+
+ipcMain.handle("scan:interfaces", async () => {
+  try {
+    const interfaces = await detectInterfaces();
+    return { ok: true, interfaces };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+      interfaces: [],
+    };
+  }
+});
+
+// --- IPC: Companion ---
+
+let companionServer = null;
+
+ipcMain.handle("companion:pair", async () => {
+  if (!companionServer) {
+    companionServer = new CompanionServer({
+      onData: (payload) => {
+        if (Array.isArray(payload.networks) && payload.networks.length > 0) {
+          const normalized = payload.networks.map((n) => ({
+            bssid: String(n.bssid ?? "").toLowerCase(),
+            ssid: String(n.ssid ?? ""),
+            signal: Number(n.rssi ?? n.signal ?? -100),
+            frequency: Number(n.frequency ?? 0),
+            channel: Number(n.channel ?? 0),
+            security: String(n.security ?? "open"),
+            source: "android",
+            deviceId: payload.deviceId,
+          }));
+          store.addAps(normalized);
+        }
+        pushToRenderer("companion:update", {
+          deviceId: payload.deviceId,
+          timestamp: payload.timestamp,
+          networkCount: payload.networks?.length ?? 0,
+        });
+      },
+    });
+  }
+
+  const token = companionServer.generateToken();
+
+  try {
+    const addr = await companionServer.start(COMPANION_PORT);
+    return { ok: true, token, address: addr };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+});
+
+ipcMain.handle("companion:status", () => ({
+  running: companionServer?.address() !== null,
+  address: companionServer?.address() ?? null,
+  token: companionServer?.token ?? null,
+}));
+
+// --- Window & store → renderer event bridge ---
+
+let mainWindow = null;
+
+function pushToRenderer(channel, data) {
+  if (mainWindow?.webContents?.isDestroyed() === false) {
+    mainWindow.webContents.send(channel, data);
+  }
+}
+
+store.on("aps", (aps) => pushToRenderer("scan:aps", aps));
+store.on("riskLog", (log) => pushToRenderer("scan:risklog", log));
+store.on("change", (state) =>
+  pushToRenderer("scan:statechange", {
+    scanning: state.scanning,
+    interface: state.interface,
+    scanIntervalMs: state.scanIntervalMs,
+  }),
+);
+store.on("appError", (entry) => pushToRenderer("app:error", entry));
+
 function createWindow() {
-  const win = new BrowserWindow({
+  mainWindow = new BrowserWindow({
     width: 1200,
     height: 800,
     webPreferences: {
@@ -199,12 +334,18 @@ function createWindow() {
     },
   });
 
-  win.loadFile(path.join(__dirname, "index.html"));
+  mainWindow.loadFile(path.join(__dirname, "index.html"));
+
+  mainWindow.on("closed", () => {
+    mainWindow = null;
+  });
 }
 
 app.whenReady().then(createWindow);
 
 app.on("window-all-closed", () => {
+  stopScanning();
+  companionServer?.stop().catch(() => {});
   if (process.platform !== "darwin") {
     app.quit();
   }

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -298,8 +298,8 @@ ipcMain.handle("companion:pair", async () => {
 });
 
 ipcMain.handle("companion:status", () => ({
-  running: companionServer !== null && companionServer.address() !== null,
-  address: companionServer?.address() ?? null,
+  running: companionServer !== null && companionServer.address !== null,
+  address: companionServer?.address ?? null,
   token: companionServer?.token ?? null,
 }));
 

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -22,6 +22,8 @@ import { CompanionServer } from "./companion-server.mjs";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const COMPANION_PACKAGE = "com.wscanplus.app";
 const COMPANION_PORT = parseInt(process.env.COMPANION_PORT ?? "47392", 10);
+// Localhost-only by default. Set COMPANION_HOST=0.0.0.0 only for explicit LAN opt-in.
+const COMPANION_HOST = process.env.COMPANION_HOST ?? "127.0.0.1";
 
 // --- ADB helpers (unchanged) ---
 
@@ -285,7 +287,7 @@ ipcMain.handle("companion:pair", async () => {
   const token = companionServer.generateToken();
 
   try {
-    const addr = await companionServer.start(COMPANION_PORT);
+    const addr = await companionServer.start(COMPANION_PORT, COMPANION_HOST);
     return { ok: true, token, address: addr };
   } catch (err) {
     return {
@@ -296,7 +298,7 @@ ipcMain.handle("companion:pair", async () => {
 });
 
 ipcMain.handle("companion:status", () => ({
-  running: companionServer?.address() !== null,
+  running: companionServer !== null && companionServer.address() !== null,
   address: companionServer?.address() ?? null,
   token: companionServer?.token ?? null,
 }));
@@ -306,7 +308,11 @@ ipcMain.handle("companion:status", () => ({
 let mainWindow = null;
 
 function pushToRenderer(channel, data) {
-  if (mainWindow?.webContents?.isDestroyed() === false) {
+  if (
+    mainWindow !== null &&
+    !mainWindow.isDestroyed() &&
+    !mainWindow.webContents.isDestroyed()
+  ) {
     mainWindow.webContents.send(channel, data);
   }
 }
@@ -349,4 +355,12 @@ app.on("window-all-closed", () => {
   if (process.platform !== "darwin") {
     app.quit();
   }
+});
+
+// Ensure cleanup runs regardless of quit path (SIGTERM, dock quit, etc.).
+// stopScanning() is synchronous; companion stop is fire-and-forget since
+// we cannot defer quit here without risking a hang.
+app.on("before-quit", () => {
+  stopScanning();
+  companionServer?.stop().catch(() => {});
 });

--- a/src/preload.mjs
+++ b/src/preload.mjs
@@ -1,7 +1,80 @@
-import { contextBridge } from "electron";
-import { ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer } from "electron";
 
 contextBridge.exposeInMainWorld("wscan", {
   version: "0.1.0",
-  runAdbPreflight: () => ipcRenderer.invoke("adb:preflight"),
+
+  // --- ADB ---
+
+  runAdbPreflight: () =>
+    ipcRenderer.invoke("adb:preflight"),
+
+  // --- Scanner ---
+
+  /** Start the scan loop. Pass an interface name or omit to auto-detect. */
+  startScan: (iface) =>
+    ipcRenderer.invoke("scan:start", iface),
+
+  stopScan: () =>
+    ipcRenderer.invoke("scan:stop"),
+
+  /** Trigger one immediate scan cycle (single-flight shared with the loop). */
+  manualScan: () =>
+    ipcRenderer.invoke("scan:manual"),
+
+  /** Returns { scanning, interface, scanIntervalMs, apCount, riskCount }. */
+  getScanState: () =>
+    ipcRenderer.invoke("scan:state"),
+
+  /** Returns { ok, interfaces[] } listing available wireless interfaces. */
+  getInterfaces: () =>
+    ipcRenderer.invoke("scan:interfaces"),
+
+  // --- Companion ---
+
+  /** Generate a pairing token and start the companion WebSocket server. */
+  pairCompanion: () =>
+    ipcRenderer.invoke("companion:pair"),
+
+  /** Returns { running, address, token }. */
+  getCompanionStatus: () =>
+    ipcRenderer.invoke("companion:status"),
+
+  // --- Push events (main → renderer) ---
+  // Each on* registers a listener for a fixed channel and returns a cleanup
+  // function. Call the returned function to remove the listener.
+
+  /** Fired after each scan cycle with the full AP array. */
+  onAps: (callback) => {
+    const handler = (_event, data) => callback(data);
+    ipcRenderer.on("scan:aps", handler);
+    return () => ipcRenderer.removeListener("scan:aps", handler);
+  },
+
+  /** Fired when the risk log changes (flagged APs only). */
+  onRiskLog: (callback) => {
+    const handler = (_event, data) => callback(data);
+    ipcRenderer.on("scan:risklog", handler);
+    return () => ipcRenderer.removeListener("scan:risklog", handler);
+  },
+
+  /** Fired when scanning starts, stops, or the interval changes. */
+  onScanState: (callback) => {
+    const handler = (_event, data) => callback(data);
+    ipcRenderer.on("scan:statechange", handler);
+    return () => ipcRenderer.removeListener("scan:statechange", handler);
+  },
+
+  /** Fired when an authenticated Android companion sends a scan payload. */
+  onCompanionUpdate: (callback) => {
+    const handler = (_event, data) => callback(data);
+    ipcRenderer.on("companion:update", handler);
+    return () => ipcRenderer.removeListener("companion:update", handler);
+  },
+
+  /** Fired when the main process records a non-fatal error. */
+  onAppError: (callback) => {
+    const handler = (_event, data) => callback(data);
+    ipcRenderer.on("app:error", handler);
+    return () => ipcRenderer.removeListener("app:error", handler);
+  },
 });

--- a/src/preload.mjs
+++ b/src/preload.mjs
@@ -45,6 +45,9 @@ contextBridge.exposeInMainWorld("wscan", {
 
   /** Fired after each scan cycle with the full AP array. */
   onAps: (callback) => {
+    if (typeof callback !== "function") {
+      throw new TypeError("onAps: callback must be a function");
+    }
     const handler = (_event, data) => callback(data);
     ipcRenderer.on("scan:aps", handler);
     return () => ipcRenderer.removeListener("scan:aps", handler);
@@ -52,6 +55,9 @@ contextBridge.exposeInMainWorld("wscan", {
 
   /** Fired when the risk log changes (flagged APs only). */
   onRiskLog: (callback) => {
+    if (typeof callback !== "function") {
+      throw new TypeError("onRiskLog: callback must be a function");
+    }
     const handler = (_event, data) => callback(data);
     ipcRenderer.on("scan:risklog", handler);
     return () => ipcRenderer.removeListener("scan:risklog", handler);
@@ -59,6 +65,9 @@ contextBridge.exposeInMainWorld("wscan", {
 
   /** Fired when scanning starts, stops, or the interval changes. */
   onScanState: (callback) => {
+    if (typeof callback !== "function") {
+      throw new TypeError("onScanState: callback must be a function");
+    }
     const handler = (_event, data) => callback(data);
     ipcRenderer.on("scan:statechange", handler);
     return () => ipcRenderer.removeListener("scan:statechange", handler);
@@ -66,6 +75,9 @@ contextBridge.exposeInMainWorld("wscan", {
 
   /** Fired when an authenticated Android companion sends a scan payload. */
   onCompanionUpdate: (callback) => {
+    if (typeof callback !== "function") {
+      throw new TypeError("onCompanionUpdate: callback must be a function");
+    }
     const handler = (_event, data) => callback(data);
     ipcRenderer.on("companion:update", handler);
     return () => ipcRenderer.removeListener("companion:update", handler);
@@ -73,6 +85,9 @@ contextBridge.exposeInMainWorld("wscan", {
 
   /** Fired when the main process records a non-fatal error. */
   onAppError: (callback) => {
+    if (typeof callback !== "function") {
+      throw new TypeError("onAppError: callback must be a function");
+    }
     const handler = (_event, data) => callback(data);
     ipcRenderer.on("app:error", handler);
     return () => ipcRenderer.removeListener("app:error", handler);

--- a/src/renderer.mjs
+++ b/src/renderer.mjs
@@ -1,87 +1,520 @@
-const statusElement = document.getElementById("status");
-const guidanceElement = document.getElementById("guidance");
-const trustedHostElement = document.getElementById("trusted-host");
-const runButton = document.getElementById("run-preflight");
-const deviceList = document.getElementById("device-list");
+// ── Renderer state ────────────────────────────────────────────────────────
+const apMap   = new Map();   // bssid → ap object
+const riskMap = new Map();   // bssid → risk entry
+let selectedBssid = null;
 
-function appendDetail(item, content) {
-  const detail = document.createElement("div");
-  detail.textContent = content;
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function formatRelTime(ts) {
+  if (!ts) return "—";
+  const d = Date.now() - ts;
+  if (d < 5_000)    return "just now";
+  if (d < 60_000)   return `${Math.floor(d / 1_000)}s ago`;
+  if (d < 3_600_000) return `${Math.floor(d / 60_000)}m ago`;
+  return `${Math.floor(d / 3_600_000)}h ago`;
+}
+
+function formatTime(ts) {
+  if (!ts) return "—";
+  return new Date(ts).toLocaleTimeString();
+}
+
+function severityRank(sev) {
+  return { high: 3, medium: 2, low: 1, info: 0 }[sev] ?? 0;
+}
+
+function signalClass(dbm) {
+  if (dbm >= -50) return "sig-strong";
+  if (dbm >= -70) return "";
+  return "sig-weak";
+}
+
+// ── Navigation ────────────────────────────────────────────────────────────
+
+function switchView(viewId) {
+  for (const btn of document.querySelectorAll(".nav-btn")) {
+    btn.classList.toggle("active", btn.dataset.view === viewId);
+  }
+  for (const view of document.querySelectorAll(".view")) {
+    view.classList.toggle("active", view.id === `view-${viewId}`);
+  }
+}
+
+function switchTab(tabId) {
+  for (const btn of document.querySelectorAll(".tab")) {
+    btn.classList.toggle("active", btn.dataset.tab === tabId);
+  }
+  for (const panel of document.querySelectorAll(".tab-panel")) {
+    panel.classList.toggle("active", panel.id === `panel-${tabId}`);
+  }
+}
+
+// ── Scan controls ─────────────────────────────────────────────────────────
+
+function updateScanControls(state) {
+  document.getElementById("btn-start").disabled  = state.scanning;
+  document.getElementById("btn-stop").disabled   = !state.scanning;
+  const badge = document.getElementById("scan-badge");
+  if (state.scanning) {
+    badge.textContent = `Scanning — ${state.interface ?? "?"}`;
+    badge.classList.add("scanning");
+  } else {
+    badge.textContent = "Idle";
+    badge.classList.remove("scanning");
+  }
+  document.getElementById("ap-count").textContent = apMap.size;
+}
+
+async function startScan() {
+  const iface = document.getElementById("iface-select").value || undefined;
+  const result = await window.wscan.startScan(iface);
+  if (!result.ok) {
+    appendLogEntry({ message: `Scan start failed: ${result.error}`, ts: Date.now() });
+  }
+}
+
+async function stopScan() {
+  await window.wscan.stopScan();
+}
+
+async function manualScan() {
+  const btn = document.getElementById("btn-manual");
+  btn.disabled = true;
+  try {
+    const result = await window.wscan.manualScan();
+    if (!result.ok) {
+      appendLogEntry({ message: `Manual scan failed: ${result.error}`, ts: Date.now() });
+    }
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+async function populateInterfaces() {
+  const result = await window.wscan.getInterfaces();
+  if (!result.ok || result.interfaces.length === 0) return;
+  const sel = document.getElementById("iface-select");
+  for (const iface of result.interfaces) {
+    const opt = document.createElement("option");
+    opt.value       = iface;
+    opt.textContent = iface;
+    sel.appendChild(opt);
+  }
+  if (result.interfaces.length === 1) {
+    sel.value = result.interfaces[0];
+  }
+}
+
+// ── AP table ──────────────────────────────────────────────────────────────
+
+function handleAps(aps) {
+  for (const ap of aps) {
+    apMap.set(ap.bssid, ap);
+  }
+  document.getElementById("ap-count").textContent = apMap.size;
+  renderApTable();
+}
+
+function renderApTable() {
+  const tbody = document.getElementById("ap-tbody");
+  const rows  = Array.from(apMap.values())
+    .sort((a, b) => b.signal - a.signal)
+    .slice(0, 200);
+
+  const frag = document.createDocumentFragment();
+  for (const ap of rows) {
+    frag.appendChild(buildApRow(ap, riskMap.get(ap.bssid)));
+  }
+  tbody.replaceChildren(frag);
+}
+
+function buildApRow(ap, risk) {
+  const tr = document.createElement("tr");
+  tr.dataset.bssid = ap.bssid;
+  if (ap.bssid === selectedBssid) tr.classList.add("selected");
+
+  const cells = [
+    () => {
+      const td = document.createElement("td");
+      if (ap.ssid) {
+        td.textContent = ap.ssid;
+      } else {
+        td.textContent = "(hidden)";
+        td.classList.add("dim");
+      }
+      return td;
+    },
+    () => {
+      const td = document.createElement("td");
+      td.textContent = ap.bssid;
+      td.classList.add("mono");
+      return td;
+    },
+    () => {
+      const td = document.createElement("td");
+      td.textContent = `${ap.signal} dBm`;
+      const cls = signalClass(ap.signal);
+      if (cls) td.classList.add(cls);
+      return td;
+    },
+    () => {
+      const td = document.createElement("td");
+      td.textContent = ap.channel || "?";
+      td.classList.add("mono");
+      return td;
+    },
+    () => {
+      const td = document.createElement("td");
+      td.textContent = ap.security || "open";
+      if (ap.security === "open" || !ap.security) td.classList.add("sec-open");
+      return td;
+    },
+    () => {
+      const td = document.createElement("td");
+      if (risk) {
+        const span = document.createElement("span");
+        span.className   = `risk-badge risk-${risk.severity}`;
+        span.textContent = risk.severity;
+        td.appendChild(span);
+      }
+      return td;
+    },
+    () => {
+      const td = document.createElement("td");
+      td.textContent = formatRelTime(ap.lastSeen);
+      td.classList.add("dim");
+      return td;
+    },
+  ];
+
+  for (const build of cells) tr.appendChild(build());
+
+  tr.addEventListener("click", () => selectAp(ap.bssid));
+  return tr;
+}
+
+// ── Threat queue ──────────────────────────────────────────────────────────
+
+function handleRiskLog(log) {
+  riskMap.clear();
+  for (const entry of log) riskMap.set(entry.bssid, entry);
+  document.getElementById("threat-count").textContent = log.length;
+  const badge = document.getElementById("threat-count");
+  if (log.length > 0) {
+    badge.classList.add("badge-danger");
+  } else {
+    badge.classList.remove("badge-danger");
+  }
+  renderApTable();
+  renderThreatQueue();
+  if (selectedBssid) renderInspector(selectedBssid);
+}
+
+function renderThreatQueue() {
+  const list   = document.getElementById("threat-list");
+  const sorted = Array.from(riskMap.values())
+    .sort((a, b) => severityRank(b.severity) - severityRank(a.severity));
+
+  const frag = document.createDocumentFragment();
+  for (const entry of sorted) {
+    const ap = apMap.get(entry.bssid);
+
+    const li = document.createElement("li");
+    li.className = `threat-item ${entry.severity}`;
+
+    const header = document.createElement("div");
+    header.className = "threat-header";
+
+    const ssidEl = document.createElement("span");
+    ssidEl.className   = "threat-ssid";
+    ssidEl.textContent = ap?.ssid || entry.ssid || "(hidden)";
+
+    const sevEl = document.createElement("span");
+    sevEl.className   = `risk-badge risk-${entry.severity}`;
+    sevEl.textContent = entry.severity;
+
+    header.appendChild(ssidEl);
+    header.appendChild(sevEl);
+    li.appendChild(header);
+
+    const bssidEl = document.createElement("div");
+    bssidEl.className   = "threat-bssid mono";
+    bssidEl.textContent = entry.bssid;
+    li.appendChild(bssidEl);
+
+    for (const reason of entry.reasons) {
+      const r = document.createElement("div");
+      r.className   = "threat-reason";
+      r.textContent = reason;
+      li.appendChild(r);
+    }
+
+    li.addEventListener("click", () => {
+      selectAp(entry.bssid);
+      switchView("scan");
+    });
+
+    frag.appendChild(li);
+  }
+  list.replaceChildren(frag);
+}
+
+// ── Inspector ─────────────────────────────────────────────────────────────
+
+function selectAp(bssid) {
+  selectedBssid = bssid;
+  for (const tr of document.querySelectorAll("#ap-tbody tr")) {
+    tr.classList.toggle("selected", tr.dataset.bssid === bssid);
+  }
+  renderInspector(bssid);
+}
+
+function renderInspector(bssid) {
+  const ap      = apMap.get(bssid);
+  const risk    = riskMap.get(bssid);
+  const content = document.getElementById("inspector-content");
+
+  if (!ap) {
+    const p = document.createElement("p");
+    p.className   = "inspector-empty";
+    p.textContent = "Select an AP to inspect";
+    content.replaceChildren(p);
+    return;
+  }
+
+  const frag = document.createDocumentFragment();
+
+  const fields = [
+    ["SSID",      ap.ssid || "(hidden)"],
+    ["BSSID",     ap.bssid],
+    ["Signal",    `${ap.signal} dBm`],
+    ["Frequency", ap.frequency ? `${ap.frequency} MHz` : "—"],
+    ["Channel",   ap.channel   || "—"],
+    ["Security",  ap.security  || "open"],
+    ["Source",    ap.source    || "desktop"],
+    ["Last seen", formatRelTime(ap.lastSeen)],
+  ];
+
+  for (const [label, value] of fields) {
+    const row = document.createElement("div");
+    row.className = "insp-row";
+
+    const lbl = document.createElement("div");
+    lbl.className   = "insp-label";
+    lbl.textContent = label;
+
+    const val = document.createElement("div");
+    val.className   = "insp-value mono";
+    val.textContent = value;
+
+    row.appendChild(lbl);
+    row.appendChild(val);
+    frag.appendChild(row);
+  }
+
+  if (risk) {
+    const divider = document.createElement("div");
+    divider.className = "insp-divider";
+    frag.appendChild(divider);
+
+    const section = document.createElement("div");
+    section.className = "insp-section";
+
+    const badge = document.createElement("span");
+    badge.className   = `risk-badge risk-${risk.severity}`;
+    badge.textContent = risk.severity;
+
+    const conf = document.createElement("span");
+    conf.className   = "insp-conf";
+    conf.textContent = `${Math.round(risk.confidence * 100)}% confidence`;
+
+    section.appendChild(badge);
+    section.appendChild(conf);
+    frag.appendChild(section);
+
+    for (const reason of risk.reasons) {
+      const r = document.createElement("div");
+      r.className   = "insp-reason";
+      r.textContent = `• ${reason}`;
+      frag.appendChild(r);
+    }
+  }
+
+  content.replaceChildren(frag);
+}
+
+// ── Event log ─────────────────────────────────────────────────────────────
+
+function appendLogEntry(entry) {
+  const container = document.getElementById("log-entries");
+
+  const div = document.createElement("div");
+  div.className = "log-entry";
+
+  const ts = document.createElement("span");
+  ts.className   = "log-ts";
+  ts.textContent = formatTime(entry.ts);
+
+  const msg = document.createElement("span");
+  msg.className   = "log-msg";
+  msg.textContent = entry.message;
+
+  div.appendChild(ts);
+  div.appendChild(msg);
+
+  container.insertBefore(div, container.firstChild);
+  while (container.childElementCount > 200) {
+    container.removeChild(container.lastChild);
+  }
+}
+
+// ── Companion ─────────────────────────────────────────────────────────────
+
+async function pairCompanion() {
+  const result = await window.wscan.pairCompanion();
+  if (!result.ok) {
+    appendLogEntry({ message: `Companion pair failed: ${result.error}`, ts: Date.now() });
+    return;
+  }
+  const block = document.getElementById("token-block");
+  block.hidden = false;
+  document.getElementById("token-value").textContent = result.token;
+  const addr = result.address;
+  document.getElementById("token-addr").textContent = addr
+    ? `ws://${addr.address}:${addr.port}`
+    : "—";
+}
+
+function handleCompanionUpdate(update) {
+  const list = document.getElementById("companion-device-list");
+
+  let item = null;
+  for (const li of list.querySelectorAll(".companion-device-item")) {
+    if (li.dataset.deviceId === update.deviceId) { item = li; break; }
+  }
+
+  if (!item) {
+    const empty = list.querySelector(".companion-empty");
+    if (empty) empty.remove();
+    item = document.createElement("li");
+    item.className    = "companion-device-item";
+    item.dataset.deviceId = update.deviceId;
+    list.appendChild(item);
+  }
+
+  item.textContent = "";
+
+  const id = document.createElement("span");
+  id.className   = "mono";
+  id.textContent = update.deviceId.slice(0, 16);
+  item.appendChild(id);
+
+  const detail = document.createElement("span");
+  detail.className   = "companion-detail";
+  detail.textContent = ` — ${update.networkCount} networks — ${formatTime(update.timestamp)}`;
   item.appendChild(detail);
 }
 
-function clearDeviceList() {
-  while (deviceList.firstChild) {
-    deviceList.removeChild(deviceList.firstChild);
-  }
-}
-
-function renderDevices(devices) {
-  clearDeviceList();
-
-  for (const device of devices) {
-    const item = document.createElement("li");
-    const parts = [
-      device.model || "Unknown model",
-      `state=${device.state}`,
-    ];
-
-    if (device.product) {
-      parts.push(`product=${device.product}`);
-    }
-
-    if (device.device) {
-      parts.push(`device=${device.device}`);
-    }
-
-    if (device.companion?.status && device.companion.status !== "unchecked") {
-      parts.push(`companion=${device.companion.status}`);
-
-      if (device.companion.versionName) {
-        parts.push(`version=${device.companion.versionName}`);
-      }
-    }
-
-    appendDetail(item, parts.join(" | "));
-
-    if (device.readiness?.label) {
-      appendDetail(item, `next=${device.readiness.label}`);
-    }
-
-    if (device.readiness?.guidance) {
-      appendDetail(item, device.readiness.guidance);
-    }
-
-    deviceList.appendChild(item);
-  }
-}
+// ── ADB preflight (devices view) ──────────────────────────────────────────
 
 async function runPreflight() {
-  statusElement.textContent = "Running ADB preflight...";
-  guidanceElement.textContent = "";
-  trustedHostElement.textContent =
-    "Only trust this desktop if it is private and under your control.";
-  runButton.disabled = true;
-  clearDeviceList();
+  const statusEl  = document.getElementById("status");
+  const guidanceEl = document.getElementById("guidance");
+  const runBtn    = document.getElementById("run-preflight");
+  const listEl    = document.getElementById("device-list");
+
+  statusEl.textContent  = "Running ADB preflight…";
+  guidanceEl.textContent = "";
+  runBtn.disabled       = true;
+  listEl.replaceChildren();
 
   try {
     const result = await window.wscan.runAdbPreflight();
-    const classification = result.classification;
+    const cls    = result.classification;
 
     if (!result.ok) {
-      statusElement.textContent = classification.title;
-      guidanceElement.textContent = `${classification.guidance} ${result.error}`;
+      statusEl.textContent  = cls.title;
+      guidanceEl.textContent = `${cls.guidance} ${result.error}`;
       return;
     }
 
-    statusElement.textContent = `${result.adbVersion} | ${classification.title}`;
-    guidanceElement.textContent = classification.guidance;
-    renderDevices(result.devices);
+    statusEl.textContent  = `${result.adbVersion} | ${cls.title}`;
+    guidanceEl.textContent = cls.guidance;
+
+    for (const device of result.devices) {
+      const li = document.createElement("li");
+
+      const parts = [device.model || "Unknown model", `state=${device.state}`];
+      if (device.product) parts.push(`product=${device.product}`);
+      if (device.device)  parts.push(`device=${device.device}`);
+      if (device.companion?.status && device.companion.status !== "unchecked") {
+        parts.push(`companion=${device.companion.status}`);
+        if (device.companion.versionName) {
+          parts.push(`version=${device.companion.versionName}`);
+        }
+      }
+
+      const main = document.createElement("div");
+      main.textContent = parts.join(" | ");
+      li.appendChild(main);
+
+      if (device.readiness?.label) {
+        const next = document.createElement("div");
+        next.textContent = `next: ${device.readiness.label}`;
+        li.appendChild(next);
+      }
+      if (device.readiness?.guidance) {
+        const guide = document.createElement("div");
+        guide.textContent = device.readiness.guidance;
+        li.appendChild(guide);
+      }
+
+      listEl.appendChild(li);
+    }
   } finally {
-    runButton.disabled = false;
+    runBtn.disabled = false;
   }
 }
 
-runButton.addEventListener("click", () => {
-  void runPreflight();
-});
+// ── Init ──────────────────────────────────────────────────────────────────
+
+async function init() {
+  // Navigation
+  for (const btn of document.querySelectorAll(".nav-btn")) {
+    btn.addEventListener("click", () => switchView(btn.dataset.view));
+  }
+
+  // Tab switching (scan view)
+  for (const btn of document.querySelectorAll(".tab")) {
+    btn.addEventListener("click", () => switchTab(btn.dataset.tab));
+  }
+
+  // Scan controls
+  document.getElementById("btn-start").addEventListener("click",  () => void startScan());
+  document.getElementById("btn-stop").addEventListener("click",   () => void stopScan());
+  document.getElementById("btn-manual").addEventListener("click", () => void manualScan());
+
+  // ADB preflight
+  document.getElementById("run-preflight").addEventListener("click", () => void runPreflight());
+
+  // Companion
+  document.getElementById("btn-pair").addEventListener("click", () => void pairCompanion());
+
+  // Push subscriptions
+  window.wscan.onAps(handleAps);
+  window.wscan.onRiskLog(handleRiskLog);
+  window.wscan.onScanState(updateScanControls);
+  window.wscan.onCompanionUpdate(handleCompanionUpdate);
+  window.wscan.onAppError(appendLogEntry);
+
+  // Load initial state
+  const [scanState, ifaceResult] = await Promise.all([
+    window.wscan.getScanState(),
+    window.wscan.getInterfaces(),
+  ]);
+
+  updateScanControls(scanState);
+  await populateInterfaces(ifaceResult);
+}
+
+void init();

--- a/src/renderer.mjs
+++ b/src/renderer.mjs
@@ -508,13 +508,10 @@ async function init() {
   window.wscan.onAppError(appendLogEntry);
 
   // Load initial state
-  const [scanState, ifaceResult] = await Promise.all([
-    window.wscan.getScanState(),
-    window.wscan.getInterfaces(),
-  ]);
+  const scanState = await window.wscan.getScanState();
 
   updateScanControls(scanState);
-  await populateInterfaces(ifaceResult);
+  await populateInterfaces();
 }
 
 void init();

--- a/src/scanner.mjs
+++ b/src/scanner.mjs
@@ -1,0 +1,276 @@
+import { spawn } from "node:child_process";
+import { store } from "./store.mjs";
+import { scoreAPs } from "./detector.mjs";
+
+const COMMAND_TIMEOUT_MS = 5_000;
+const SIGKILL_DELAY_MS = 250;
+
+export class ScanError extends Error {
+  constructor(message, { code = null, signal = null } = {}) {
+    super(message);
+    this.name = "ScanError";
+    this.code = code;
+    this.signal = signal;
+  }
+}
+
+/**
+ * Spawn a command with a hard 5 s timeout.
+ * SIGTERM first, SIGKILL 250 ms later if still alive.
+ * Cleanup timers always run.
+ */
+export function runCommand(
+  cmd,
+  args,
+  timeoutMs = COMMAND_TIMEOUT_MS,
+) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { windowsHide: true });
+    let stdout = "";
+    let stderr = "";
+    let forceKillTimer = null;
+
+    const timeoutId = setTimeout(() => {
+      child.kill("SIGTERM");
+      forceKillTimer = setTimeout(() => {
+        child.kill("SIGKILL");
+      }, SIGKILL_DELAY_MS);
+    }, timeoutMs);
+
+    function cleanup() {
+      clearTimeout(timeoutId);
+      if (forceKillTimer) clearTimeout(forceKillTimer);
+    }
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", (err) => {
+      cleanup();
+      reject(new ScanError(err.message, { code: err.code }));
+    });
+
+    child.on("close", (code, signal) => {
+      cleanup();
+      if (signal === "SIGTERM" || signal === "SIGKILL") {
+        reject(new ScanError(`Command timed out: ${cmd}`, { signal }));
+        return;
+      }
+      if (code !== 0) {
+        reject(
+          new ScanError(
+            stderr.trim() || `${cmd} exited with code ${code}`,
+            { code },
+          ),
+        );
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+/**
+ * Parse `iw dev` output and return interface names.
+ */
+export function parseIwDevOutput(raw) {
+  const ifaces = [];
+  for (const line of raw.split("\n")) {
+    const m = line.trim().match(/^Interface\s+(\S+)/);
+    if (m) ifaces.push(m[1]);
+  }
+  return ifaces;
+}
+
+/**
+ * Parse `iw dev <iface> scan` output into AP objects.
+ */
+export function parseScanOutput(raw) {
+  const aps = [];
+  let current = null;
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+
+    // New BSS block — flush previous
+    const bssMatch = trimmed.match(/^BSS ([0-9a-f:]{17})\(/i);
+    if (bssMatch) {
+      if (current) aps.push(finalize(current));
+      current = {
+        bssid: bssMatch[1].toLowerCase(),
+        ssid: null,
+        frequency: 0,
+        channel: 0,
+        signal: -100,
+        security: "open",
+      };
+      continue;
+    }
+
+    if (!current) continue;
+
+    const freqM = trimmed.match(/^freq:\s*(\d+)/);
+    if (freqM) {
+      current.frequency = parseInt(freqM[1], 10);
+      current.channel = freqToChannel(current.frequency);
+      continue;
+    }
+
+    const sigM = trimmed.match(/^signal:\s*(-?\d+(?:\.\d+)?)\s*dBm/);
+    if (sigM) {
+      current.signal = parseFloat(sigM[1]);
+      continue;
+    }
+
+    // SSID line — empty value means hidden
+    if (trimmed.startsWith("SSID:")) {
+      current.ssid = trimmed.slice(5).trim();
+      continue;
+    }
+
+    if (trimmed.startsWith("RSN:")) {
+      current.security = "wpa2";
+      continue;
+    }
+
+    if (trimmed.startsWith("WPA:") && current.security !== "wpa2") {
+      current.security = "wpa";
+      continue;
+    }
+
+    // capability Privacy without RSN/WPA → WEP or unknown legacy encryption
+    if (
+      trimmed.startsWith("capability:") &&
+      current.security === "open" &&
+      trimmed.includes("Privacy")
+    ) {
+      current.security = "wep";
+    }
+  }
+
+  if (current) aps.push(finalize(current));
+  return aps;
+}
+
+function finalize(ap) {
+  return { ...ap, ssid: ap.ssid ?? "" };
+}
+
+/**
+ * Convert frequency (MHz) to 802.11 channel number.
+ */
+export function freqToChannel(freqMHz) {
+  if (freqMHz === 2484) return 14;
+  if (freqMHz >= 2412 && freqMHz <= 2472) {
+    return Math.round((freqMHz - 2407) / 5);
+  }
+  if (freqMHz >= 5170 && freqMHz <= 5825) {
+    return Math.round((freqMHz - 5000) / 5);
+  }
+  if (freqMHz >= 5955 && freqMHz <= 7115) {
+    return Math.round((freqMHz - 5950) / 5);
+  }
+  return 0;
+}
+
+// --- Scan loop state (module-level singletons) ---
+
+let activeScanPromise = null;
+let scanLoopTimer = null;
+
+async function runScanAndProcess() {
+  const iface = store.state.interface;
+  if (!iface) {
+    throw new ScanError("No wireless interface configured");
+  }
+
+  const raw = await runCommand("iw", ["dev", iface, "scan"]);
+  const aps = parseScanOutput(raw);
+
+  if (aps.length > 0) {
+    store.addAps(aps);
+    const flagged = scoreAPs(aps, store.state.aps).filter(
+      (e) => e.severity !== "info",
+    );
+    if (flagged.length > 0) {
+      store.addRiskEntries(flagged);
+    }
+  }
+
+  return aps;
+}
+
+/**
+ * Single-flight wrapper. A scan already in progress is awaited rather
+ * than started again. This prevents overlapping executions.
+ */
+export async function executeScanCycle() {
+  if (!activeScanPromise) {
+    activeScanPromise = runScanAndProcess().finally(() => {
+      activeScanPromise = null;
+    });
+  }
+  return activeScanPromise;
+}
+
+function scheduleNextScan() {
+  if (!store.state.scanning) return;
+  clearTimeout(scanLoopTimer);
+  scanLoopTimer = setTimeout(() => {
+    void scanLoop();
+  }, store.state.scanIntervalMs);
+}
+
+async function scanLoop() {
+  if (!store.state.scanning) return;
+  try {
+    await executeScanCycle();
+  } catch (err) {
+    store.addError(err);
+  } finally {
+    if (store.state.scanning) {
+      scheduleNextScan();
+    }
+  }
+}
+
+/**
+ * Detect available wireless interfaces via `iw dev`.
+ */
+export async function detectInterfaces() {
+  const raw = await runCommand("iw", ["dev"]);
+  return parseIwDevOutput(raw);
+}
+
+/**
+ * Start the self-scheduling scan loop.
+ * Auto-detects the first available interface if none is provided.
+ */
+export async function startScanning(iface) {
+  if (store.state.scanning) return;
+
+  let resolvedIface = iface;
+  if (!resolvedIface) {
+    const ifaces = await detectInterfaces();
+    if (ifaces.length === 0) {
+      throw new ScanError("No wireless interfaces detected");
+    }
+    resolvedIface = ifaces[0];
+  }
+
+  store.update({ scanning: true, interface: resolvedIface });
+  void scanLoop();
+}
+
+/**
+ * Stop the scan loop and cancel any pending timer.
+ */
+export function stopScanning() {
+  store.update({ scanning: false });
+  clearTimeout(scanLoopTimer);
+  scanLoopTimer = null;
+}

--- a/src/store.mjs
+++ b/src/store.mjs
@@ -1,0 +1,81 @@
+import { EventEmitter } from "node:events";
+
+const RISK_LOG_MAX = 1000;
+const RISK_LOG_TTL_MS = 60_000;
+
+class Store extends EventEmitter {
+  #state;
+
+  constructor() {
+    super();
+    this.#state = {
+      scanning: false,
+      scanIntervalMs: 30_000,
+      interface: null,
+      aps: new Map(),       // bssid -> ap object (last seen)
+      riskLog: [],          // bounded, TTL-managed risk entries
+      errors: [],           // bounded error log
+      companionDevices: new Map(), // deviceId -> session metadata
+    };
+  }
+
+  get state() {
+    return this.#state;
+  }
+
+  update(patch) {
+    Object.assign(this.#state, patch);
+    this.emit("change", this.#state);
+  }
+
+  addAps(newAps) {
+    const now = Date.now();
+    for (const ap of newAps) {
+      this.#state.aps.set(ap.bssid, { ...ap, lastSeen: now });
+    }
+    this.emit("aps", Array.from(this.#state.aps.values()));
+  }
+
+  addRiskEntries(entries) {
+    const now = Date.now();
+
+    // Prune TTL-expired entries
+    this.#state.riskLog = this.#state.riskLog.filter(
+      (e) => now - e.ts < RISK_LOG_TTL_MS,
+    );
+
+    // Upsert by dedupe key: bssid + severity
+    for (const entry of entries) {
+      const key = `${entry.bssid}:${entry.severity}`;
+      const idx = this.#state.riskLog.findIndex(
+        (e) => `${e.bssid}:${e.severity}` === key,
+      );
+      if (idx >= 0) {
+        this.#state.riskLog[idx] = { ...entry, ts: now };
+      } else {
+        this.#state.riskLog.push({ ...entry, ts: now });
+      }
+    }
+
+    // Enforce max bound
+    if (this.#state.riskLog.length > RISK_LOG_MAX) {
+      this.#state.riskLog = this.#state.riskLog.slice(-RISK_LOG_MAX);
+    }
+
+    this.emit("riskLog", this.#state.riskLog);
+  }
+
+  addError(err) {
+    const entry = {
+      message: err instanceof Error ? err.message : String(err),
+      ts: Date.now(),
+    };
+    this.#state.errors.push(entry);
+    if (this.#state.errors.length > 100) {
+      this.#state.errors = this.#state.errors.slice(-100);
+    }
+    this.emit("appError", entry);
+  }
+}
+
+export const store = new Store();

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,535 @@
+/* ── Theme tokens ───────────────────────────────────────────────────────── */
+:root {
+  --bg:          #0B1220;
+  --surface:     #121A2B;
+  --elevated:    #1A2336;
+  --border:      #1E2D3E;
+  --primary:     #2196F3;
+  --primary-dk:  #1565C0;
+  --success:     #2E7D32;
+  --warning:     #F9A825;
+  --danger:      #C62828;
+  --text:        #C8D6E8;
+  --text-dim:    #4A6278;
+  --font-ui:     system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --font-mono:   'Courier New', Courier, monospace;
+}
+
+/* ── Reset ──────────────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+/* ── Shell grid ─────────────────────────────────────────────────────────── */
+.shell {
+  display: grid;
+  grid-template-areas:
+    "nav workspace inspector"
+    "nav log      log";
+  grid-template-columns: 148px 1fr 264px;
+  grid-template-rows: 1fr 140px;
+  height: 100vh;
+}
+
+/* ── Nav rail ───────────────────────────────────────────────────────────── */
+.nav-rail {
+  grid-area: nav;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+}
+
+.nav-brand {
+  color: var(--primary);
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  padding: 16px 14px 14px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.nav-btn {
+  display: block;
+  width: 100%;
+  background: none;
+  border: none;
+  border-left: 3px solid transparent;
+  color: var(--text-dim);
+  padding: 10px 14px;
+  text-align: left;
+  cursor: pointer;
+  font-size: 12px;
+  font-family: var(--font-ui);
+  transition: color 0.1s;
+}
+
+.nav-btn:hover { color: var(--text); background: var(--elevated); }
+
+.nav-btn.active {
+  color: var(--text);
+  border-left-color: var(--primary);
+  background: var(--elevated);
+}
+
+/* ── Workspace ──────────────────────────────────────────────────────────── */
+.workspace {
+  grid-area: workspace;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+}
+
+/* ── Views (nav-switched) ───────────────────────────────────────────────── */
+.view {
+  display: none;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+}
+
+.view.active { display: flex; }
+
+/* ── View header ────────────────────────────────────────────────────────── */
+.view-header {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: 8px 14px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+  min-height: 42px;
+}
+
+.view-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--text-dim);
+  min-width: 80px;
+}
+
+/* ── Tab bar ────────────────────────────────────────────────────────────── */
+.tab-bar {
+  display: flex;
+  gap: 2px;
+}
+
+.tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-dim);
+  padding: 4px 10px;
+  font-size: 12px;
+  font-family: var(--font-ui);
+  cursor: pointer;
+  transition: color 0.1s;
+}
+
+.tab:hover { color: var(--text); }
+
+.tab.active {
+  color: var(--text);
+  border-bottom-color: var(--primary);
+}
+
+/* ── Scan controls ──────────────────────────────────────────────────────── */
+.scan-controls {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.iface-select {
+  background: var(--elevated);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 3px 6px;
+  font-size: 11px;
+  border-radius: 3px;
+  font-family: var(--font-ui);
+  max-width: 120px;
+}
+
+/* ── Buttons ────────────────────────────────────────────────────────────── */
+.btn {
+  background: var(--elevated);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 4px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 12px;
+  font-family: var(--font-ui);
+}
+
+.btn:hover:not(:disabled) {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: var(--primary-dk);
+  border-color: var(--primary-dk);
+  color: #fff;
+}
+
+/* ── Scan status badge ──────────────────────────────────────────────────── */
+.scan-badge {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.scan-badge.scanning {
+  color: var(--success);
+  border-color: var(--success);
+}
+
+/* ── Count badges (tab labels) ──────────────────────────────────────────── */
+.badge {
+  background: var(--elevated);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 10px;
+  padding: 1px 5px;
+  color: var(--text-dim);
+  margin-left: 4px;
+  font-family: var(--font-mono);
+}
+
+.badge-danger {
+  background: #3a0a0a;
+  color: var(--danger);
+  border-color: var(--danger);
+}
+
+/* ── Tab panels ─────────────────────────────────────────────────────────── */
+.tab-panel {
+  display: none;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+}
+
+.tab-panel.active { display: flex; }
+
+/* ── AP table ───────────────────────────────────────────────────────────── */
+.table-wrap {
+  overflow-y: auto;
+  flex: 1;
+}
+
+.ap-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.ap-table th {
+  background: var(--surface);
+  color: var(--text-dim);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 5px 10px;
+  text-align: left;
+  position: sticky;
+  top: 0;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.ap-table td {
+  padding: 5px 10px;
+  border-bottom: 1px solid var(--border);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.ap-table tr:hover td { background: var(--elevated); }
+
+.ap-table tr.selected td { background: var(--elevated); }
+
+.ap-table tr.selected td:first-child {
+  border-left: 2px solid var(--primary);
+  padding-left: 8px;
+}
+
+/* AP table column widths */
+.ap-table th:nth-child(1), .ap-table td:nth-child(1) { width: 26%; }
+.ap-table th:nth-child(2), .ap-table td:nth-child(2) { width: 18%; }
+.ap-table th:nth-child(3), .ap-table td:nth-child(3) { width: 10%; }
+.ap-table th:nth-child(4), .ap-table td:nth-child(4) { width: 6%;  }
+.ap-table th:nth-child(5), .ap-table td:nth-child(5) { width: 9%;  }
+.ap-table th:nth-child(6), .ap-table td:nth-child(6) { width: 7%;  }
+.ap-table th:nth-child(7), .ap-table td:nth-child(7) { width: auto; }
+
+/* ── Signal strength ────────────────────────────────────────────────────── */
+.sig-strong { color: var(--success); }
+.sig-weak   { color: var(--text-dim); }
+
+/* ── Security label ─────────────────────────────────────────────────────── */
+.sec-open { color: var(--warning); }
+
+/* ── Risk badges ────────────────────────────────────────────────────────── */
+.risk-badge {
+  display: inline-block;
+  padding: 1px 5px;
+  border-radius: 2px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  font-family: var(--font-ui);
+}
+
+.risk-high   { background: #3a0a0a; color: var(--danger);  }
+.risk-medium { background: #2a1800; color: var(--warning); }
+.risk-low    { background: #0a1a2a; color: var(--primary); }
+
+/* ── Threat queue ───────────────────────────────────────────────────────── */
+.threat-list {
+  list-style: none;
+  padding: 8px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.threat-item {
+  background: var(--elevated);
+  border: 1px solid var(--border);
+  border-left-width: 3px;
+  border-radius: 3px;
+  padding: 8px 10px;
+  margin-bottom: 5px;
+  cursor: pointer;
+}
+
+.threat-item:hover { border-color: var(--text-dim); border-left-width: 3px; }
+
+.threat-item.high   { border-left-color: var(--danger);  }
+.threat-item.medium { border-left-color: var(--warning); }
+.threat-item.low    { border-left-color: var(--primary); }
+
+.threat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+
+.threat-ssid   { font-weight: 600; font-size: 13px; }
+.threat-bssid  { font-size: 11px; color: var(--text-dim); margin-bottom: 4px; }
+.threat-reason { font-size: 11px; color: var(--text-dim); margin-top: 2px; }
+
+/* ── Right inspector ────────────────────────────────────────────────────── */
+.inspector {
+  grid-area: inspector;
+  background: var(--surface);
+  border-left: 1px solid var(--border);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.inspector-header {
+  padding: 10px 12px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--text-dim);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  position: sticky;
+  top: 0;
+  background: var(--surface);
+}
+
+.inspector-empty {
+  color: var(--text-dim);
+  font-size: 12px;
+  text-align: center;
+  padding-top: 24px;
+}
+
+#inspector-content { padding: 10px 12px; }
+
+.insp-row    { margin-bottom: 10px; }
+.insp-label  { font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-dim); margin-bottom: 2px; }
+.insp-value  { font-size: 12px; word-break: break-all; }
+
+.insp-divider { border-top: 1px solid var(--border); margin: 12px 0; }
+
+.insp-section { display: flex; align-items: center; gap: 6px; margin-bottom: 8px; }
+.insp-conf    { font-size: 11px; color: var(--text-dim); }
+.insp-reason  { font-size: 11px; color: var(--text-dim); padding: 2px 0; }
+
+/* ── Event log ──────────────────────────────────────────────────────────── */
+.log-drawer {
+  grid-area: log;
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.log-header {
+  padding: 6px 12px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--text-dim);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.log-entries {
+  overflow-y: auto;
+  flex: 1;
+  padding: 4px 0;
+}
+
+.log-entry {
+  display: flex;
+  gap: 10px;
+  padding: 2px 12px;
+  border-bottom: 1px solid var(--border);
+  font-size: 11px;
+}
+
+.log-ts  { color: var(--text-dim); flex-shrink: 0; font-family: var(--font-mono); }
+.log-msg { color: var(--text); }
+
+/* ── Devices view ───────────────────────────────────────────────────────── */
+.devices-content {
+  padding: 14px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.trusted-host-notice {
+  color: var(--warning);
+  font-size: 12px;
+  margin-bottom: 12px;
+}
+
+#status   { font-size: 13px; margin-bottom: 6px; }
+#guidance { font-size: 12px; color: var(--text-dim); margin-bottom: 12px; }
+
+#device-list { list-style: none; }
+
+#device-list li {
+  background: var(--elevated);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 8px 10px;
+  margin-bottom: 6px;
+  font-size: 12px;
+}
+
+#device-list li div {
+  color: var(--text-dim);
+  font-size: 11px;
+  margin-top: 4px;
+}
+
+#device-list li div:first-child {
+  color: var(--text);
+  font-size: 12px;
+  margin-top: 0;
+}
+
+/* ── Companion view ─────────────────────────────────────────────────────── */
+.companion-content {
+  padding: 14px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.companion-section { margin-bottom: 22px; }
+
+.section-label {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--text-dim);
+  margin-bottom: 8px;
+}
+
+.section-note {
+  font-size: 12px;
+  color: var(--text-dim);
+  line-height: 1.6;
+  margin-bottom: 10px;
+}
+
+.token-block  { margin-top: 12px; }
+.token-label  { font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-dim); margin-bottom: 4px; }
+
+.token-value {
+  background: var(--elevated);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 8px 10px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--primary);
+  word-break: break-all;
+  margin-bottom: 6px;
+  user-select: text;
+}
+
+.token-addr { font-size: 12px; color: var(--text-dim); font-family: var(--font-mono); }
+
+.companion-device-list { list-style: none; margin-top: 4px; }
+
+.companion-device-item {
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+}
+
+.companion-detail { color: var(--text-dim); }
+.companion-empty  { color: var(--text-dim); font-size: 12px; font-style: italic; padding: 6px 0; }
+
+/* ── Utilities ──────────────────────────────────────────────────────────── */
+.mono { font-family: var(--font-mono); }
+.dim  { color: var(--text-dim); }


### PR DESCRIPTION
## Summary

- **Engine**: self-scheduling scan loop (no `setInterval`), single-flight `executeScanCycle`, hard 5 s command timeout with SIGTERM → SIGKILL fallback, structured `ScanError`, `iw`-based interface detection and scan output parser
- **Store**: shared state singleton with bounded risk log (TTL 60 s, max 1000 entries, `bssid:severity` dedupe key) and EventEmitter bridge to renderer
- **Detector**: deterministic AP scoring — hidden SSID, open network, WEP, signal anomaly, SSID collision; no ML, no MAC/OUI attribution; `SEVERITY` enum; `scoreAPs()` filters to flagged entries only
- **Companion server**: WebSocket server with token-based pairing (`randomBytes(16)`), stale-timestamp rejection (±2 min), monotonic sequence enforcement per device, rate limiting (10 msg/s), localhost-only default — `COMPANION_HOST` env opt-in for LAN
- **Hardening pass**: explicit token string type guard, `Number.isInteger` sequence guard, `running` status bug fix, `before-quit` lifecycle handler, explicit `isDestroyed()` push guard
- **Preload**: narrow `contextBridge` bridge — invoke wrappers + `on*` push subscriptions with cleanup returns and `typeof callback` guards; no raw `ipcRenderer` exposure
- **UI**: 4-panel dark tactical shell — AP inventory table (top 200 by signal), threat queue (severity-sorted), device inspector, event log; scan controls with interface selector; companion pairing view; ADB preflight preserved in Devices view; zero `innerHTML`, zero inline styles (CSP `style-src 'self'` maintained)

## Test plan

- [ ] `npm ci` — clean install
- [ ] `npm test` — all 4 existing scaffold tests pass
- [ ] `npm run lint` — no ESLint errors
- [ ] `npm audit --json` — verify no new vulnerabilities introduced by `ws@8.20.0` (existing `brace-expansion` and `lodash` findings are pre-existing in `electron-builder` devDep chain)
- [ ] Smoke: `npm start` loads 4-panel UI, ADB preflight runs from Devices view
- [ ] Smoke: Start scan with no `iw` available returns `{ ok: false }` and logs to event log without crashing

https://claude.ai/code/session_015Vekvk8rCTZQ2GTgmVMTzQ